### PR TITLE
Fix encode_plus AttributeError with tokenizers 0.22+

### DIFF
--- a/py/dart/model.py
+++ b/py/dart/model.py
@@ -18,7 +18,7 @@ class DartModel:
         self.set_seed(seed)
 
         inputs = tokenizer.tokenizer(prompt, return_tensors="pt").input_ids
-        bad_words_ids = tokenizer.tokenizer.encode_plus(ban_tags).input_ids
+        bad_words_ids = tokenizer.tokenizer.encode(ban_tags)
         if len(bad_words_ids) == 0:
             bad_words_ids = None
         else:

--- a/py/nodes/advanced/token_ids.py
+++ b/py/nodes/advanced/token_ids.py
@@ -47,6 +47,6 @@ class DanbooruTagsTransformerRemoveTagToken(BaseNode):
     FUNCTION = "remove"
 
     def remove(self, tokenizer: DartTokenizer, token_ids, remove_tags):
-        remove_tag_token_ids = tokenizer.tokenizer.encode_plus(remove_tags).input_ids
+        remove_tag_token_ids = tokenizer.tokenizer.encode(remove_tags)
         token_ids = [token for token in token_ids if token not in remove_tag_token_ids]
         return (token_ids,)

--- a/py/nodes/generate.py
+++ b/py/nodes/generate.py
@@ -69,7 +69,7 @@ class DanbooruTagsTransformerGenerate(BaseNode):
         token_ids = outputs[0]
 
         # remove tags
-        remove_tag_token_ids = tokenizer.tokenizer.encode_plus(remove_tags).input_ids
+        remove_tag_token_ids = tokenizer.tokenizer.encode(remove_tags)
         token_ids = [token for token in token_ids if token not in remove_tag_token_ids]
 
         if animagine_order:


### PR DESCRIPTION
`encode_plus` was removed in tokenizers 0.22+, causing an AttributeError on generation.

Fixed by replacing all three instances with `encode()` and removing `.input_ids`:
- py/nodes/advanced/token_ids.py
- py/dart/model.py
- py/nodes/generate.py

Tested and working on tokenizers 0.22.2.